### PR TITLE
Fixes 'Modify pip install command tags' #14

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,8 @@ You can download the driver and agent release packages directly from F5 Networks
 
 .. code-block:: text
 
-    $ pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@2.0.1a1
-    $ pip install git+https://github.com/F5Networks/f5-openstack-agent@2.0.1a1
+    $ pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v2.0.1a1
+    $ pip install git+https://github.com/F5Networks/f5-openstack-agent@v2.0.1a1
 
 
 Configuration


### PR DESCRIPTION
@jlongstaf 

Fixes #14 

Problem: the `pip install` commands exclude the 'v' that comes before the release number (i.e., 'v2.0.1a1').

Solution: I corrected the release tags in the `pip install` commands.

