### PR TITLE
Fixes #24 - remove install f5-sdk command from pre-reqs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,13 @@ For release |release|, you will need to install the following dependencies your 
 
     .. code-block:: shell
 
-        $ curl -O https://github.com/F5Networks/neutron-lbaas/releases/download/v2.0.1a1/f5.tgz
+        $ curl -O https://github
+        .com/F5Networks/neutron-lbaas/releases/download/v2.0.1a2/f5.tgz
+
+    .. note::
+
+        If you get a redirect error when using the above ``curl`` command,
+        add ``-L``.
 
     Install on CentOS:
 

--- a/README.rst
+++ b/README.rst
@@ -59,12 +59,6 @@ Before You Begin
 ----------------
 For release |release|, you will need to install the following dependencies your Neutron controller host *before* installing the F5® LBaaSv2 plugin packages.
 
-.. topic:: Install the F5® SDK
-
-    .. code-block:: shell
-
-        $ pip install f5-sdk
-
 .. topic:: Download the F5® LBaaSv2 service provider package and add it to the python path for ``neutron_lbaas``.
 
     Download from GitHub
@@ -80,7 +74,6 @@ For release |release|, you will need to install the following dependencies your 
         # tar xvf f5.tgz -C /usr/lib/python2.7/site-packages/neutron_lbaas/drivers/
 
     Install on Ubuntu:
-
 
     .. code-block:: text
 


### PR DESCRIPTION
@zancas @mattgreene 

#### What issues does this address?
Fixes #24 & #33 

#### What's this change do?
I removed the instruction to install the f5-sdk from the 'Before you begin' section of the readme.
I added a note regarding adding `-L` to the `curl` command.

#### Where should the reviewer start?
view changes below

#### Any background context?

