### PR TITLE
2.0.1a2 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,8 @@ You can download the driver and agent release packages directly from F5 Networks
 
 .. code-block:: text
 
-    $ pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v2.0.1a1
-    $ pip install git+https://github.com/F5Networks/f5-openstack-agent@v2.0.1a1
+    $ pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v2.0.1a2
+    $ pip install git+https://github.com/F5Networks/f5-openstack-agent@v2.0.1a2
 
 
 Configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ author = u'F5 Networks'
 # The short X.Y version.
 version = u'2.0.1'
 # The full version, including alpha/beta/rc tags.
-release = u'2.0.1a1'
+release = u'2.0.1a2'
 
 # OpenStack release
 openstack_release = "Liberty"

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,7 +16,7 @@ This release provides an implementation of the OpenStack Neutron LBaaS 2.0 drive
 
 Release Highlights
 ------------------
-Support for creating, updating, and deleting LBaaS v2 load balancers, listeners, pools, members, and health monitors. See :ref:`Getting Started with F5® OpenStack LBaaSv2 <getting-started-lbaasv2>` for code examples.
+This release provides initial functionality with a limited set of configuration objects for use by OpenStack Neutron LBaaSv2 service plugin. It has support for L3 binding and preliminary support for performing L2 orchestration.
 
 Caveats
 -------


### PR DESCRIPTION
Bump version number to v2.0.1a2 in readme.
Update release notes for v2.0.1a2.
Bump version number to v2.0.1a2 in conf.py.