### PR TITLE
LBaaSv2 doc updates for usability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,12 @@ f5-openstack-lbaasv2
 
 Introduction
 ------------
+
 This repo contains the documentation for F5®'s OpenStack LBaaSv2 plugin. The LBaaSv2 plugin allows you to provision BIG-IP® load balancing services – including virtual IPs, pools, device service groups, and health monitoring – in an OpenStack cloud.
 
 Subprojects
 -----------
+
 The LBaaSv2 plugin comprises packages from different F5 Networks® projects:
 
  - `F5Networks/f5-openstack-lbaasv2-driver <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
@@ -40,12 +42,10 @@ Releases
 
 The latest release is |release|. See the :ref:`Release Notes <release-notes>` for more information.
 
-.. warning::
-
-    Alpha and beta releases are **unsupported** development releases. We welcome feedback and bug reporting for these releases; see `For Developers <https://github.com/F5Networks/f5-openstack-lbaasv2#for-developers>`_ for more information.
 
 Documentation
 -------------
+
 See the `Deployment Guide <http://f5-openstack-lbaasv2.rtfd.org/en/liberty/f5-lbaasv2-plugin-deployment-guide.html>`_ for installation and configuration instructions.
 
 .. note::
@@ -60,6 +60,7 @@ See the `Deployment Guide <http://f5-openstack-lbaasv2.rtfd.org/en/liberty/f5-lb
 
 Compatibility
 -------------
+
 This plugin is compatible with OpenStack |openstack|. If you are using Kilo or earlier, you'll have to use the `LBaaSv1 plugin <https://github.com/F5Networks/f5-openstack-lbaasv1>`_. See the `F5® OpenStack Releases and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_ for more information.
 
 .. _for-developers:

--- a/docs/coding-example-lbaasv2.rst
+++ b/docs/coding-example-lbaasv2.rst
@@ -1,13 +1,13 @@
-.. _getting-started-lbaasv2:
+.. _coding-example-lbaasv2:
 
-Getting Started with the F5® OpenStack LBaaSv2 Plugin
-=====================================================
+F5® OpenStack LBaaSv2 Plugin - Coding Example
+=============================================
 
 .. toctree::
     :hidden:
     :maxdepth: 1
 
-To help you get started with the F5® OpenStack LBaaSv2 plugin, we've provided some examples below. This series of examples shows how to configure basic load balancing via the Neutron CLI.
+We've provided some code examples below to help you get started with the F5® OpenStack LBaaSv2 plugin. This series demonstrates how to configure basic load balancing via the Neutron CLI.
 
 To access the full Neutron LBaaS command set, please see the `OpenStack CLI Documentation <http://docs.openstack.org/cli-reference/neutron.html>`_. LBaaSv2 commands all begin with ``lbaas``.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ author = u'F5 Networks'
 # built documents.
 #
 # The short X.Y version.
-version = u'8.0'
+version = u'Liberty'
 # The full version, including alpha/beta/rc tags.
 release = u'v8.0.1'
 

--- a/docs/f5-lbaasv2-plugin-deployment-guide.rst
+++ b/docs/f5-lbaasv2-plugin-deployment-guide.rst
@@ -11,8 +11,15 @@ Release
 -------
 
 .. include:: ../README.rst
-    :start-line: 40
-    :end-line: 45
+    :start-line: 42
+    :end-line: 44
+
+Compatibility
+-------------
+
+.. include:: ../README.rst
+    :start-line: 63
+    :end-line: 65
 
 Before You Begin
 ----------------
@@ -30,14 +37,14 @@ Configuration
 -------------
 
 Neutron
-~~~~~~~
+```````
 
 .. include:: includes/topic_configure-neutron-lbaasv2.rst
     :start-line: 3
 
 
 F5® Agent
-~~~~~~~~~
+`````````
 
 .. include:: includes/topic_configure-the-agent.rst
     :start-line: 3
@@ -53,14 +60,14 @@ Usage
     The OpenStack LBaaSv2 CLI commands begin with ``lbaas``. See the `OpenStack CLI documentation <http://docs.openstack.org/cli-reference/neutron.html>`_ for more information.
 
 Restrictions
-~~~~~~~~~~~~
+````````````
 
 .. include:: includes/topic_restrictions.rst
     :start-line: 3
 
 .. seealso::
 
-    :ref:`Getting Started <getting-started-lbaasv2>`
+    :ref:`Coding Example <coding-example-lbaasv2>`
 
     :ref:`Troubleshooting <troubleshooting>`
 

--- a/docs/f5-lbaasv2-plugin-deployment-guide.rst
+++ b/docs/f5-lbaasv2-plugin-deployment-guide.rst
@@ -18,13 +18,13 @@ Before You Begin
 ----------------
 
 .. include:: includes/topic_before-you-begin.rst
-    :start-line: 3
+    :start-line: 5
 
 Installation
 ------------
 
 .. include:: includes/topic_install-f5-lbaasv2-packages.rst
-    :start-line: 3
+    :start-line: 5
 
 Configuration
 -------------

--- a/docs/includes/topic_before-you-begin.rst
+++ b/docs/includes/topic_before-you-begin.rst
@@ -1,7 +1,26 @@
+.. _lbaasv2-deploy-before-you-begin:
+
 Before You Begin
 ----------------
 
-For release |release|, you will need to take the steps below *before* installing the F5® LBaaSv2 plugin packages. This adds the necessary F5® service provider package to your Neutron controller.
+Prerequisites
+`````````````
+
+In order to follow this guide, you will need the following:
+
+* A functional OpenStack |openstack| environment with at least one controller node, one compute node, and one network node.
+* An undercloud\* or overcloud\** BIG-IP® deployment.
+* Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/liberty/>`_ for more information.
+* F5® service provider package installed on Neutron controller (see below).
+
+\* BIG-IP® VE deployed as an OpenStack instance
+\** BIG-IP® VE or hardware deployed outside of OpenStack
+
+
+Install the F5® Service Provider Package
+````````````````````````````````````````
+
+Install the F5® LBaaSv2 service provider package *before* you :ref:`install the F5® LBaaSv2 plugin packages <install-f5-agent-driver>`. If the F5® service provider package isn't present on your Neutron controller,  the F5® agent and LBaaSv2 driver will not work.
 
 .. topic:: Download the F5® LBaaSv2 service provider package and add it to the python path for ``neutron_lbaas``.
 
@@ -12,14 +31,16 @@ For release |release|, you will need to take the steps below *before* installing
         $ curl -O -L https://github.com/F5Networks/neutron-lbaas/releases/download/v8.0.1/f5.tgz
 
 
-    2a. Install on CentOS:
+    2. Install the service provider package.
+
+    a. CentOS:
 
     .. code-block:: text
 
-        # tar xvf f5.tgz -C /usr/lib/python2.7/site-packages/neutron_lbaas/drivers/
+        $ sudo tar xvf f5.tgz -C /usr/lib/python2.7/site-packages/neutron_lbaas/drivers/
 
-    2b. Install on Ubuntu:
+    b. Ubuntu:
 
     .. code-block:: text
 
-        # tar xvf f5.tgz –C /usr/local/lib/python2.7/dist-packages/neutron_lbaas/drivers/
+        $ sudo tar xvf f5.tgz –C /usr/local/lib/python2.7/dist-packages/neutron_lbaas/drivers/

--- a/docs/includes/topic_before-you-begin.rst
+++ b/docs/includes/topic_before-you-begin.rst
@@ -43,4 +43,4 @@ Install the F5® LBaaSv2 service provider package *before* you :ref:`install the
 
     .. code-block:: text
 
-        $ sudo tar xvf f5.tgz –C /usr/local/lib/python2.7/dist-packages/neutron_lbaas/drivers/
+        $ sudo tar xvf f5.tgz –C /usr/lib/python2.7/dist-packages/neutron_lbaas/drivers/

--- a/docs/includes/topic_before-you-begin.rst
+++ b/docs/includes/topic_before-you-begin.rst
@@ -9,12 +9,13 @@ Prerequisites
 In order to follow this guide, you will need the following:
 
 * A functional OpenStack |openstack| environment with at least one controller node, one compute node, and one network node.
-* An undercloud\* or overcloud\** BIG-IP® deployment.
+* An undercloud [#f1]_ or overcloud [#f2]_ BIG-IP® deployment.
 * Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/liberty/>`_ for more information.
 * F5® service provider package installed on Neutron controller (see below).
 
-\* BIG-IP® VE deployed as an OpenStack instance
-\** BIG-IP® VE or hardware deployed outside of OpenStack
+
+.. [#f1] BIG-IP® VE deployed as an OpenStack instance
+.. [#f2] BIG-IP® VE or hardware deployed outside of OpenStack
 
 
 Install the F5® Service Provider Package

--- a/docs/includes/topic_configure-neutron-lbaasv2.rst
+++ b/docs/includes/topic_configure-neutron-lbaasv2.rst
@@ -3,9 +3,15 @@ Configure Neutron for LBaaSv2
 
 You will need to make a few configurations in your Neutron environment in order to use the F5® OpenStack LBaasv2 plugin.
 
-1. Edit the Neutron LBaaS config file -- :file:`/etc/neutron/neutron_lbaas.conf`.
+Edit the Neutron LBaaS config file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    In the ``[service_providers]`` section, add ``F5Networks`` as the lbaasv2 service provider as shown below.
+You'll need to edit :file:`/etc/neutron/neutron_lbaas.conf` to tell Neutron to use the F5® LBaaSv2 plugin.
+
+Set 'F5Networks' as the lbaasv2 service provider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Edit the ``service_providers`` section of :file:`/etc/neutron/neutron_lbaas.conf` as shown below to set 'F5Networks' as the LBaaSv2 service provider.
 
     .. code-block:: text
         :emphasize-lines: 4
@@ -16,14 +22,16 @@ You will need to make a few configurations in your Neutron environment in order 
         service_provider = LOADBALANCERV2:F5Networks:neutron_lbaas.drivers.f5.driver_v2.F5LBaaSV2Driver:default
         ...
 
-    .. note::
+.. note::
 
-        If there is an active entry for the F5® LBaaSv1 service provider driver, comment (#) it out.
+    If there is an active entry for the F5® LBaaSv1 service provider driver, comment (#) it out.
 
+Define the Neutron LBaaS Service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-2. Edit the ``[DEFAULT]`` section of the Neutron config file -- :file:`/etc/neutron/neutron.conf`.
+Edit the ``[DEFAULT]`` section of the Neutron config file -- :file:`/etc/neutron/neutron.conf`.
 
-    * Add the lbaasv2 service plugin as shown below.
+1. Add the lbaasv2 service plugin as shown below.
 
     .. code-block:: text
 
@@ -33,9 +41,12 @@ You will need to make a few configurations in your Neutron environment in order 
         service_plugins = [already defined plugins],neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2
         ...
 
-    * Remove the entry for the LBaaSv1 service plugin (``lbaas``).
+2. Remove the entry for the LBaaSv1 service plugin (``lbaas``).
 
-3. Restart the ``neutron-server`` service.
+Restart Neutron
+^^^^^^^^^^^^^^^
+
+Use the command appropriate for your OS to restart the ``neutron-server`` service.
 
     .. code-block:: text
 

--- a/docs/includes/topic_configure-the-agent.rst
+++ b/docs/includes/topic_configure-the-agent.rst
@@ -1,11 +1,13 @@
 Configure the F5® OpenStack Agent
 ---------------------------------
 
-1. Edit the agent configuration file -- :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` -- as appropriate for your environment.
+Edit the agent configuration file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following configurations are supported in |release|. See the :ref:`Release Notes <release-notes>` or the config file for more information about these features.
+Edit :file:`/etc/neutron/services/f5/f5-openstack-agent.ini` as appropriate for your environment. The configurations listed here are supported in |release|. See the :ref:`Release Notes <release-notes>` or the config file for more information about these features.
 
-.. topic:: Device Settings
+Device Settings
+^^^^^^^^^^^^^^^
 
     .. code-block:: text
 
@@ -23,8 +25,8 @@ The following configurations are supported in |release|. See the :ref:`Release N
         f5_sync_mode = replication
         #
 
-
-.. topic:: L2/L3 Segmentation Mode Settings
+L2/L3 Segmentation Mode Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. code-block:: text
 
@@ -56,8 +58,8 @@ The following configurations are supported in |release|. See the :ref:`Release N
         #
         #
 
-
-.. topic:: Global Routed Mode Settings
+Global Routed Mode Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. code-block:: text
 
@@ -70,9 +72,8 @@ The following configurations are supported in |release|. See the :ref:`Release N
         f5_global_routed_mode = True
         #
 
-
-
-.. topic:: Device Driver - iControl® Driver Setting
+Device Driver - iControl® Driver Setting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     .. code-block:: text
 
@@ -92,14 +93,16 @@ The following configurations are supported in |release|. See the :ref:`Release N
         icontrol_password = admin
         #
 
+Start the F5® agent
+~~~~~~~~~~~~~~~~~~~
 
-2. Start the agent using the command appropriate for your OS.
+Use the command(s) appropriate for your OS to start the agent.
 
-.. code-block:: text
+    .. code-block:: text
 
-    $ sudo service f5-openstack-agent start             \\ Debian/Ubuntu
+        $ sudo service f5-oslbaasv2-agent start             \\ Debian/Ubuntu
 
-    $ sudo systemctl enable f5-openstack-agent           \\ RedHat/CentOS
-    $ sudo systemctl start f5-openstack-agent
+        $ sudo systemctl enable f5-openstack-agent           \\ RedHat/CentOS
+        $ sudo systemctl start f5-openstack-agent
 
 

--- a/docs/includes/topic_install-f5-lbaasv2-packages.rst
+++ b/docs/includes/topic_install-f5-lbaasv2-packages.rst
@@ -1,5 +1,7 @@
-Install the F5® Packages
-------------------------
+.. _install-f5-agent-driver:
+
+Install the F5® Agent and Driver Packages
+-----------------------------------------
 
 .. note::
 

--- a/docs/includes/topic_tip-stop-agent.rst
+++ b/docs/includes/topic_tip-stop-agent.rst
@@ -7,5 +7,5 @@ Tip - How to stop the agent
 
     .. code-block:: text
 
-        $ sudo service f5-openstack-agent stop            \\ Debian/Ubuntu
+        $ sudo service f5-oslbaasv2-agent stop            \\ Debian/Ubuntu
         $ sudo systemctl stop f5-openstack-agent.service  \\ RedHat/CentOS

--- a/docs/includes/topic_troubleshooting-f5agent.rst
+++ b/docs/includes/topic_troubleshooting-f5agent.rst
@@ -18,7 +18,7 @@ Here are a few things you can try:
 
     .. code-block:: text
 
-        $ sudo service f5-openstack-agent status           \\ Debian/Ubuntu
+        $ sudo service f5-oslbaasv2-agent status           \\ Debian/Ubuntu
         $ sudo systemctl status f5-openstack-agent.service \\ RedHat/CentOS
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,18 +7,26 @@ F5® OpenStack LBaaSv2
 
     <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
 
-.. toctree::
-    :hidden:
-
-    release_notes
-    Getting Started <getting-started-lbaasv2>
-    Deployment Guide <f5-lbaasv2-plugin-deployment-guide>
-    troubleshooting
-
 .. include:: ../README.rst
     :start-line: 26
-    :end-line: 63
+    :end-line: 44
 
 .. include:: ../README.rst
-    :start-line: 90
+    :start-line: 60
+    :end-line: 65
+
+Site Contents
+-------------
+
+.. toctree::
+    :maxdepth: 2
+
+    Release Notes - v8.0.1 <release_notes>
+    Deployment Guide <f5-lbaasv2-plugin-deployment-guide>
+    Coding Example <coding-example-lbaasv2>
+    troubleshooting
+
+
+
+
 


### PR DESCRIPTION
@mattgreene @swormke 

#### What issues does this address?
Fixes #46, #50 

#### What's this change do?
- reorganizes the documentation for better usability and clarity
- clarifies the prerequisites
- moved the OpenStack version that the doc pertains to under the doc set name in the sidebar (in place of the version number that used to appear there) 

#### Where should the reviewer start?
View the changes below, or build the docs locally:
```
git clone -b feature.lbaasv2-docs https://github.com/jputrino/f5-openstack-lbaasv2.git
cd f5-openstack-lbaasv2
pip install -R requirements.docs.txt
sphinx-build docs/ docs/_build
\\view the docs in the /_build dir in your browser
```


#### Any background context?